### PR TITLE
[FE ⬅🚀FE_SONU] 회원가입 로직 성공 및 인증서 제출 로직 진행 + 역할군 별 로그인 라우팅 분리

### DIFF
--- a/virtualFittingApp/bun.lock
+++ b/virtualFittingApp/bun.lock
@@ -23,6 +23,7 @@
         "googleapis": "^149.0.0",
         "gsap": "^3.12.7",
         "js-cookie": "^3.0.5",
+        "jwt-decode": "^4.0.0",
         "lenis": "^1.2.3",
         "lucide-react": "^0.539.0",
         "motion": "^12.5.0",
@@ -694,6 +695,8 @@
     "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
 
     "jws": ["jws@4.0.0", "", { "dependencies": { "jwa": "^2.0.0", "safe-buffer": "^5.0.1" } }, "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg=="],
+
+    "jwt-decode": ["jwt-decode@4.0.0", "", {}, "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA=="],
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 

--- a/virtualFittingApp/package.json
+++ b/virtualFittingApp/package.json
@@ -30,6 +30,7 @@
     "googleapis": "^149.0.0",
     "gsap": "^3.12.7",
     "js-cookie": "^3.0.5",
+    "jwt-decode": "^4.0.0",
     "lenis": "^1.2.3",
     "lucide-react": "^0.539.0",
     "motion": "^12.5.0",

--- a/virtualFittingApp/src/app/brand/BrandRouter.tsx
+++ b/virtualFittingApp/src/app/brand/BrandRouter.tsx
@@ -1,6 +1,7 @@
 import { Route, Routes, useLocation } from "react-router-dom";
 import {
   BrandAnalytics,
+  BrandAuthenticate,
   BrandCoupon,
   BrandDashboard,
   BrandPage,
@@ -18,9 +19,9 @@ function BrandRouter() {
     <Routes location={location} key={location.pathname}>
       <Route path="brand">
         <Route index element={<BrandPage />} />
-        <Route path="signup" />
         <Route element={<BrandLayout />}>
           <Route path="dashboard" index element={<BrandDashboard />} />
+          <Route path="auth" element={<BrandAuthenticate />} />
           <Route path="product">
             <Route index element={<BrandProductListPage />} />
             <Route path="create" element={<BrandProductCreate />} />

--- a/virtualFittingApp/src/pages/auth/ui/BrandSignUpPage.tsx
+++ b/virtualFittingApp/src/pages/auth/ui/BrandSignUpPage.tsx
@@ -9,8 +9,6 @@ function BrandSignUpPage() {
   const {
     brandUserSignUp,
     step,
-    businessRegistration,
-    setBusinessRegistration,
     onSubmitSignUp,
     onClickNextStep,
     onClickPrevStep,
@@ -18,7 +16,6 @@ function BrandSignUpPage() {
     onChangeId,
     onChangePassword,
     onChangePhoneNumber,
-    onChangeRegistration,
     onChangeFirmAddress,
     onChangeFirmEmail,
     onChangeFirmName,
@@ -48,9 +45,6 @@ function BrandSignUpPage() {
       {step === 1 && (
         <BrandUserCompanySignUpPanel
           brandUserInfo={brandUserSignUp}
-          files={businessRegistration}
-          setFiles={setBusinessRegistration}
-          onChangeRegistration={onChangeRegistration}
           onChangeFirmAddress={onChangeFirmAddress}
           onChangeFirmEmail={onChangeFirmEmail}
           onChangeFirmName={onChangeFirmName}

--- a/virtualFittingApp/src/pages/brand/api/brand.action.ts
+++ b/virtualFittingApp/src/pages/brand/api/brand.action.ts
@@ -1,7 +1,10 @@
 "use server";
 
-import { API_BASILIUM, ProductServerResponseType } from "@/shared";
-import { BrandUserType } from "@/pages/brand/types/brandUser";
+import { API_BASILIUM, FileItem, ProductServerResponseType } from "@/shared";
+import {
+  BrandAuthenticationType,
+  BrandUserType,
+} from "@/pages/brand/types/brandUser";
 import axios from "axios";
 
 export const MODIFY_BRAND_INFO = async (request: BrandUserType) => {
@@ -58,5 +61,51 @@ export const GET_BRAND_PRODUCT_LIST = async ({
     if (axios.isAxiosError(err)) {
       console.error(err.message);
     }
+  }
+};
+
+export const GET_BRAND_AUTHENTICATION = async () => {
+  try {
+    const res = await API_BASILIUM.get("/b1/brandUsers/me/busniess-cert");
+    if (res.status === 200) {
+      return res.data as BrandAuthenticationType;
+    }
+  } catch (err) {
+    if (!axios.isAxiosError(err)) return err;
+    if (err.status === 401) {
+      console.log("내잘못");
+      console.log(err.message);
+      return err;
+    }
+    console.log(err);
+    return err;
+  }
+};
+
+export const POST_BRAND_AUTHENTICATION = async (fileItem: FileItem) => {
+  try {
+    const formData = new FormData();
+    formData.append("file", fileItem.file);
+    const res = await API_BASILIUM.post(
+      "/b1/brandUsers/me/busniess-cert",
+      formData,
+      {
+        headers: {
+          "Content-Type": "multipart/form-data;",
+        },
+      },
+    );
+    if (res.status === 200) {
+      return true;
+    }
+  } catch (err) {
+    if (!axios.isAxiosError(err)) return err;
+    if (err.status === 401) {
+      console.log("내잘못");
+      console.log(err.message);
+      return err;
+    }
+    console.log(err);
+    return err;
   }
 };

--- a/virtualFittingApp/src/pages/brand/index.ts
+++ b/virtualFittingApp/src/pages/brand/index.ts
@@ -7,3 +7,4 @@ export { BrandProductListPage } from "@/pages/brand/ui/BrandProductListPage";
 export { BrandPaymentPage } from "@/pages/brand/ui/BrandPaymentPage";
 export { BrandAnalytics } from "@/pages/brand/ui/BrandAnalytics";
 export { BrandCoupon } from "@/pages/brand/ui/BrandCoupon";
+export { BrandAuthenticate } from "@/pages/brand/ui/BrandAuthenticate";

--- a/virtualFittingApp/src/pages/brand/types/brandUser.d.ts
+++ b/virtualFittingApp/src/pages/brand/types/brandUser.d.ts
@@ -15,3 +15,18 @@ export type RedisProductDto = {
   productDesc: string;
   productPrice: number;
 };
+
+export interface BrandAuthenticationType {
+  timestamp: string;
+  status: number;
+  code: string;
+  message: string;
+  data: BrandAuthenticationDataType;
+}
+
+type BrandAuthenticationDataType = {
+  userNumber: number;
+  busniessRegistration: string;
+  fileName: string;
+  url: string;
+};

--- a/virtualFittingApp/src/pages/brand/ui/BrandAuthenticate.tsx
+++ b/virtualFittingApp/src/pages/brand/ui/BrandAuthenticate.tsx
@@ -1,0 +1,118 @@
+import { DragAndDropFile, FileItem } from "@/shared";
+import { useEffect, useState } from "react";
+import styled from "styled-components";
+import {
+  GET_BRAND_AUTHENTICATION,
+  POST_BRAND_AUTHENTICATION,
+} from "../api/brand.action";
+import { BrandAuthenticationType } from "../types/brandUser";
+
+function BrandAuthenticate() {
+  const [file, setFile] = useState<FileItem[]>([]);
+  const [authenticationData, setAuthenticationData] =
+    useState<BrandAuthenticationType>({
+      timestamp: "",
+      status: 0,
+      code: "",
+      message: "",
+      data: {
+        userNumber: 0,
+        busniessRegistration: "",
+        fileName: "",
+        url: "",
+      },
+    });
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const data = await GET_BRAND_AUTHENTICATION();
+      if (!data) throw new Error("저장되어 있는 정보가 없습니다.");
+    };
+    fetchData();
+  }, []);
+
+  const onUpload = async () => {
+    if (!file) {
+      alert("파일을 등록해주세요!");
+      return;
+    }
+    const res = await POST_BRAND_AUTHENTICATION(file[0]);
+    if (res === true) {
+    }
+  };
+
+  return (
+    <Wrapper>
+      <TitleContainer>
+        <Title>사업자 인증 화면</Title>
+        <SubTitle>
+          Basilium 쇼핑몰에 상품을 입점하기 위해서는 사업자 등록증에 관련하여
+          인증이 필요합니다.
+        </SubTitle>
+      </TitleContainer>
+      <ContentContainer>
+        <DragAndDropFile files={file} setFiles={setFile} />
+      </ContentContainer>
+      <ButtonContainer>
+        <Button onClick={onUpload}>
+          <Text>제출하기</Text>
+        </Button>
+      </ButtonContainer>
+    </Wrapper>
+  );
+}
+
+export { BrandAuthenticate };
+
+const Wrapper = styled.main`
+  width: 100%;
+`;
+
+const TitleContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-flow: column wrap;
+  justify-content: flex-start;
+  align-items: flex-start;
+`;
+
+const Title = styled.h1`
+  font-size: 1rem;
+  font-weight: 600;
+  color: black;
+`;
+
+const SubTitle = styled.span`
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: black;
+`;
+
+const ContentContainer = styled.div`
+  width: 100%;
+`;
+
+const ButtonContainer = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Button = styled.div`
+  width: 20rem;
+  height: 2rem;
+  transition: 0.15s all ease;
+  border: 1px solid #121512;
+  border-radius: 0.8rem;
+  cursor: pointer;
+  &:hover {
+    background-color: #d9d9d9;
+  }
+`;
+
+const Text = styled.span`
+  font-size: 0.65rem;
+  font-weight: 500;
+  color: black;
+`;

--- a/virtualFittingApp/src/shared/config/axios/AxiosConfig.ts
+++ b/virtualFittingApp/src/shared/config/axios/AxiosConfig.ts
@@ -24,7 +24,7 @@ type headers = {
 
 API_BASILIUM.defaults.headers = {
   "Content-Type": "application/json;",
-  Accept: "application/json",
+  Accept: "*/*",
 } as headers & HeadersDefaults;
 
 API_BASILIUM.interceptors.request.use(

--- a/virtualFittingApp/src/widgets/auth/api/auth.action.ts
+++ b/virtualFittingApp/src/widgets/auth/api/auth.action.ts
@@ -23,7 +23,7 @@ export const userLogin = async (userInfo: LoginRequestDto) => {
       console.log(res.data);
       Cookies.set("access-token", res.data.data.accessToken);
       Cookies.set("refresh-token", res.data.data.refreshToken);
-      return true;
+      return res.data.data.accessToken;
     }
   } catch (err) {
     if (isAxiosError(err)) {

--- a/virtualFittingApp/src/widgets/auth/api/brandAuth.action.ts
+++ b/virtualFittingApp/src/widgets/auth/api/brandAuth.action.ts
@@ -4,7 +4,7 @@ import { isAxiosError } from "axios";
 
 export const brandUserSignUpApi = async (props: BrandUserSignUpRequestDto) => {
   try {
-    const res = await API_BASILIUM.post("/brandUsers/signup", props);
+    const res = await API_BASILIUM.post("/b1/brandUsers/signup", props);
     if (res.status === 201) {
       return true;
     } else {

--- a/virtualFittingApp/src/widgets/auth/api/brandAuth.action.ts
+++ b/virtualFittingApp/src/widgets/auth/api/brandAuth.action.ts
@@ -12,8 +12,10 @@ export const brandUserSignUpApi = async (props: BrandUserSignUpRequestDto) => {
     }
   } catch (err) {
     if (!isAxiosError(err)) {
+      console.log(err);
       return err;
     }
+    console.log(err);
     return err.status;
   }
 };

--- a/virtualFittingApp/src/widgets/auth/hooks/useBrandSignup.tsx
+++ b/virtualFittingApp/src/widgets/auth/hooks/useBrandSignup.tsx
@@ -13,17 +13,17 @@ function useBrandSignup() {
       userNumber: 0,
       id: "",
       password: "",
-      userGrade: "BRONZE",
       emailAddress: "",
-      loginType: "",
       phoneNumber: "",
+      userGrade: "BRONZE",
+      loginType: "NORMAL",
       userImageUrl: "",
       userProfileImageUrl: "",
       firmName: "",
       firmAddress: "",
-      firmWebUrl: "",
       businessRegistration: "",
       businessRegistrationCertificateImageUrl: "",
+      firmWebUrl: "",
       firmEmail: "",
       firmPhone: "",
       saleAllowed: false,
@@ -111,6 +111,7 @@ function useBrandSignup() {
       setStateMsg("signUp");
       const signUpRes = await brandUserSignUpApi(brandUserSignUp);
       if (!signUpRes) throw new Error("회원가입 실패");
+      router("/login");
     } catch (err) {
       if (!isAxiosError(err)) {
         console.error(err);

--- a/virtualFittingApp/src/widgets/auth/hooks/useBrandSignup.tsx
+++ b/virtualFittingApp/src/widgets/auth/hooks/useBrandSignup.tsx
@@ -1,22 +1,16 @@
 import { type ChangeEvent, useState } from "react";
 import { BrandUserSignUpRequestDto } from "../types/login";
-import {
-  brandUserSignUpApi,
-  updateUserInfo,
-  uploadBusinessRegistration,
-} from "../api/brandAuth.action";
+import { brandUserSignUpApi } from "../api/brandAuth.action";
 import { useNavigate } from "react-router-dom";
 import { FileItem } from "@/shared";
 import { isAxiosError } from "axios";
-
-// onChange 함수들 조금 더 깔끔하게 보낼 수 있도록 설정
-// page layer 에서 너무 많은 prop 을 전달한다.
 
 function useBrandSignup() {
   const router = useNavigate();
 
   const [brandUserSignUp, setBrandUserSignUp] =
     useState<BrandUserSignUpRequestDto>({
+      userNumber: 0,
       id: "",
       password: "",
       userGrade: "BRONZE",
@@ -117,19 +111,6 @@ function useBrandSignup() {
       setStateMsg("signUp");
       const signUpRes = await brandUserSignUpApi(brandUserSignUp);
       if (!signUpRes) throw new Error("회원가입 실패");
-
-      setStateMsg("upload");
-      if (businessRegistration.length > 0) {
-        const uploadRes =
-          await uploadBusinessRegistration(businessRegistration);
-        if (!uploadRes) throw new Error("사진 업로드 실패");
-      }
-
-      setStateMsg("update");
-      const updateRes = await updateUserInfo(brandUserSignUp);
-      if (!updateRes) throw new Error("회원정보 수정 실패");
-
-      setStateMsg("complete");
     } catch (err) {
       if (!isAxiosError(err)) {
         console.error(err);

--- a/virtualFittingApp/src/widgets/auth/hooks/useLogin.tsx
+++ b/virtualFittingApp/src/widgets/auth/hooks/useLogin.tsx
@@ -2,6 +2,11 @@ import { ChangeEvent, MouseEvent, useState } from "react";
 import { type LoginRequestDto } from "@/widgets/auth/types/login";
 import { userLogin } from "../api/auth.action";
 import { useNavigate } from "react-router-dom";
+import { type JwtPayload, jwtDecode } from "jwt-decode";
+
+interface BasiliumJwtPayload extends JwtPayload {
+  role: string;
+}
 
 function useLogin() {
   const router = useNavigate();
@@ -32,8 +37,17 @@ function useLogin() {
       alert("로그인에 실패하였습니다.");
       return;
     }
+    if (res === 500) {
+      alert("로그인에 실패하였습니다.");
+      return;
+    }
     alert("로그인에 성공하였습니다!");
-    router("/store");
+    const decodedToken = jwtDecode<BasiliumJwtPayload>(res);
+    if (decodedToken.role === "BRAND") {
+      router("/brand/dashboard");
+    } else {
+      router("/store");
+    }
   };
 
   const onClickBrandSignUp = () => {

--- a/virtualFittingApp/src/widgets/auth/types/login.d.ts
+++ b/virtualFittingApp/src/widgets/auth/types/login.d.ts
@@ -28,6 +28,7 @@ export type NormalUserSignUpRequestDto = {
 };
 
 export type BrandUserSignUpRequestDto = {
+  userNumber: number;
   id: string;
   password: string;
   emailAddress: string;

--- a/virtualFittingApp/src/widgets/auth/ui/BrandUserCompanySignUpPanel.tsx
+++ b/virtualFittingApp/src/widgets/auth/ui/BrandUserCompanySignUpPanel.tsx
@@ -1,30 +1,24 @@
-import { BREAKPOINTS, DragAndDropFile, FileItem } from "@/shared";
+import { BREAKPOINTS, FileItem } from "@/shared";
 import styled from "styled-components";
 import { BrandUserSignUpRequestDto } from "../types/login";
 import { Dispatch, type ChangeEvent, SetStateAction } from "react";
 
 type BrandUserCompanySignUpPanelType = {
   brandUserInfo: BrandUserSignUpRequestDto;
-  files: FileItem[];
-  setFiles: Dispatch<SetStateAction<FileItem[]>>;
   onChangeFirmName: (e: ChangeEvent<HTMLInputElement>) => void;
   onChangeFirmAddress: (e: ChangeEvent<HTMLInputElement>) => void;
   onChangeFirmWebUrl: (e: ChangeEvent<HTMLInputElement>) => void;
   onChangeFirmEmail: (e: ChangeEvent<HTMLInputElement>) => void;
   onChangeFirmPhoneNumber: (e: ChangeEvent<HTMLInputElement>) => void;
-  onChangeRegistration: (e: ChangeEvent<HTMLInputElement>) => void;
 };
 
 function BrandUserCompanySignUpPanel({
   brandUserInfo,
-  files,
-  setFiles,
   onChangeFirmName,
   onChangeFirmAddress,
   onChangeFirmEmail,
   onChangeFirmPhoneNumber,
   onChangeFirmWebUrl,
-  onChangeRegistration,
 }: BrandUserCompanySignUpPanelType) {
   return (
     <Wrapper>
@@ -45,20 +39,6 @@ function BrandUserCompanySignUpPanel({
             value={brandUserInfo.firmAddress}
             onChange={onChangeFirmAddress}
           />
-        </InfoBox>
-        <InfoBox>
-          <SubTitle>사업자 등록증</SubTitle>
-          <BusinessRegistrationContainer>
-            <Text>사업자 명</Text>
-            <TextInput
-              value={brandUserInfo.businessRegistration}
-              onChange={onChangeRegistration}
-            />
-          </BusinessRegistrationContainer>
-          <BusinessRegistrationContainer>
-            <Text>사업자 등록증 증명 서류</Text>
-            <DragAndDropFile files={files} setFiles={setFiles} />
-          </BusinessRegistrationContainer>
         </InfoBox>
         <InfoBox>
           <SubTitle>회사 WebSite URL</SubTitle>
@@ -164,19 +144,4 @@ const TextInput = styled.input.attrs({ type: "text" })`
   &:focus {
     outline: 1px solid #121519;
   }
-`;
-
-const BusinessRegistrationContainer = styled.div`
-  width: 100%;
-  display: flex;
-  flex-flow: column wrap;
-  justify-content: flex-start;
-  align-items: flex-start;
-  gap: 1rem;
-`;
-
-const Text = styled.span`
-  font-size: 0.9rem;
-  font-weight: 500;
-  color: black;
 `;

--- a/virtualFittingApp/src/widgets/auth/ui/BrandUserSignUp.tsx
+++ b/virtualFittingApp/src/widgets/auth/ui/BrandUserSignUp.tsx
@@ -1,7 +1,7 @@
 import { BREAKPOINTS } from "@/shared";
 import styled from "styled-components";
 import { BrandUserSignUpRequestDto } from "../types/login";
-import { type ChangeEvent } from "react";
+import { useState, type ChangeEvent } from "react";
 
 type BrandUserSignUpPanelType = {
   brandUserInfo: BrandUserSignUpRequestDto;
@@ -18,6 +18,11 @@ function BrandUserSignUp({
   onChangeEmail,
   onChangePhoneNumber,
 }: BrandUserSignUpPanelType) {
+  const [showPassword, setShowPassword] = useState<boolean>(false);
+  const togglePasswordVisibility = (): void => {
+    setShowPassword(!showPassword);
+  };
+
   return (
     <Wrapper>
       <InfoContainer>
@@ -31,9 +36,37 @@ function BrandUserSignUp({
         <InfoBox>
           <SubTitle>PASSWORD</SubTitle>
           <PasswordInput
+            type={showPassword ? "text" : "password"}
             value={brandUserInfo.password}
             onChange={onChangePassword}
           />
+          <ToggleButton
+            type="button"
+            onClick={togglePasswordVisibility}
+            aria-label={showPassword ? "비밀번호 숨기기" : "비밀번호 보기"}
+          >
+            <EyeIcon
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              {showPassword ? (
+                // 눈 감은 아이콘
+                <>
+                  <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94L17.94 17.94z" />
+                  <line x1="1" y1="1" x2="23" y2="23" />
+                  <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19l-6.93-6.93a2.99 2.99 0 0 0-4.17-.11L9.9 4.24z" />
+                </>
+              ) : (
+                // 눈 뜬 아이콘
+                <>
+                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                  <circle cx="12" cy="12" r="3" />
+                </>
+              )}
+            </EyeIcon>
+          </ToggleButton>
         </InfoBox>
         <InfoBox>
           <SubTitle>EMAIL</SubTitle>
@@ -104,6 +137,7 @@ const InfoContainer = styled.div`
 `;
 
 const InfoBox = styled.div`
+  position: relative;
   width: 100%;
   display: flex;
   flex-flow: column wrap;
@@ -148,4 +182,34 @@ const PasswordInput = styled.input`
   &:focus {
     outline: 1px solid #121519;
   }
+`;
+
+const ToggleButton = styled.button`
+  position: absolute;
+  top: 2.3rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 8px;
+  color: #6b7280;
+  transition: color 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    color: #667eea;
+  }
+
+  &:focus {
+    outline: none;
+    color: #667eea;
+  }
+`;
+
+const EyeIcon = styled.svg`
+  width: 20px;
+  height: 20px;
+  transition: opacity 0.2s ease;
 `;


### PR DESCRIPTION
### 📌 Related Issue Number
related: #141 

### 🍀 무엇을 위한 PR인가요?
- [x] 기능 추가 : 역할군별 로그인 라우팅 분리, (브랜드 유저, 일반유저) 유저 회원가입 로직 완료, 인증서 제출 로직 진행 중
- [x] 스타일 : 인증서 제출 화면 구성 중, 브랜드 유저 회원가입 화면 스타일 완료, 패스워드 visible, invisible 설정

### 🚀 Description & 기대 결과


### 📢 Notes 논의하고 싶은 내용
- userNumber 를 무조건 제출해야만 BrandUser 가 회원가입이 성공했는데, 이 값은 어떻게 하면되는지?


### 📸 Screenshot

