### PR TITLE
[FE⬅FE_seah] 메인페이지 텍스트 등장 순서 변경

### DIFF
--- a/virtualFittingApp/src/pages/main/ui/MainPage.tsx
+++ b/virtualFittingApp/src/pages/main/ui/MainPage.tsx
@@ -169,7 +169,7 @@ const Section = styled.div`
 
 const TextSection = styled.div`
   width: 100%;
-  height: 110vh;
+  height: 100vh;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/virtualFittingApp/src/pages/product/list/ui/product-list-page.tsx
+++ b/virtualFittingApp/src/pages/product/list/ui/product-list-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import styled from "styled-components";
 import { useNavigate } from "react-router-dom";
 
@@ -13,6 +13,7 @@ function ProductListPage() {
   const navigate = useNavigate();
   const [products, setProducts] = useState<Product[]>([]);
   const [loading, setLoading] = useState(true);
+  const productGridRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const loadProducts = async () => {
@@ -36,9 +37,9 @@ function ProductListPage() {
   return (
     <Wrapper>
       <CarouselContainer>
-        <AdvertisementCarousel />
+        <AdvertisementCarousel targetRef={productGridRef} />
       </CarouselContainer>
-      <ProductGrid>
+      <ProductGrid ref={productGridRef}>
         {products.map((product) => (
           <ProductCard
             key={product.productId}

--- a/virtualFittingApp/src/widgets/advertisement-carousel/ui/advertisement-carousel.tsx
+++ b/virtualFittingApp/src/widgets/advertisement-carousel/ui/advertisement-carousel.tsx
@@ -7,10 +7,23 @@ import PauseCircleIcon from '@mui/icons-material/PauseCircle';
 import { rawSvgContent } from "@/widgets/main/model/constants";
 import { BREAKPOINTS } from "@/shared";
 
-function AdvertisementCarousel() {
+interface CarouselProps {
+  targetRef: React.RefObject<HTMLElement>;
+}
+
+function AdvertisementCarousel({ targetRef }: CarouselProps) {
   const [banners, setBanners] = useState<Banner[]>([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isPaused, setIsPaused] = useState(false);
+  
+  const handleScrollToGrid = () => {
+    if (targetRef.current) {
+      window.scrollTo({
+        top: targetRef.current.offsetTop,
+        behavior: 'smooth'
+      });
+    }
+  };
 
   useEffect(() => {
     const loadBanners = async () => {
@@ -70,7 +83,10 @@ function AdvertisementCarousel() {
             {isPaused ? <PlayCircleIcon fontSize="large" /> : <PauseCircleIcon fontSize="large" />}
         </PlayPauseButton>
       </Pagination>
-      <ScrollArrow dangerouslySetInnerHTML={{ __html: rawSvgContent }} />
+      <ScrollArrow 
+        dangerouslySetInnerHTML={{ __html: rawSvgContent }}
+        onClick={handleScrollToGrid} 
+      />
     </Wrapper>
   );
 }

--- a/virtualFittingApp/src/widgets/main/ui/AITextSection.tsx
+++ b/virtualFittingApp/src/widgets/main/ui/AITextSection.tsx
@@ -66,7 +66,7 @@ function AITextSection() {
           ease: "none",
           scrollTrigger: {
             trigger: wrapperRef.current,
-            start: "top bottom",
+            start: "middle top",
             end: "bottom top",
             scrub: true,
             id: "service-content-mobile-move",

--- a/virtualFittingApp/src/widgets/main/ui/CommerceTextSection.tsx
+++ b/virtualFittingApp/src/widgets/main/ui/CommerceTextSection.tsx
@@ -66,7 +66,7 @@ function CommerceTextSection() {
           ease: "none",
           scrollTrigger: {
             trigger: wrapperRef.current,
-            start: "top bottom",
+            start: "middle top",
             end: "bottom top",
             scrub: true,
             id: "service-content-mobile-move",
@@ -117,8 +117,8 @@ function CommerceTextSection() {
 const SectionContainer = styled.div`
   position: relative;
   width: 100%;
-  height: 100vh;
-  overflow: hidden;
+  height: 150vh;
+  overflow: visible;
 `;
 
 const ScreenText = styled.div`
@@ -153,7 +153,7 @@ const Wrapper = styled.div`
   height: 100vh;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: end; 
   overflow: hidden; 
   padding-right: 10vw;

--- a/virtualFittingApp/src/widgets/main/ui/ServiceTextSection.tsx
+++ b/virtualFittingApp/src/widgets/main/ui/ServiceTextSection.tsx
@@ -66,7 +66,7 @@ function ServiceTextSection() {
           ease: "none",
           scrollTrigger: {
             trigger: wrapperRef.current,
-            start: "top bottom",
+            start: "middle top",
             end: "bottom top",
             scrub: true,
             id: "service-content-mobile-move",


### PR DESCRIPTION
### 🍀 무엇을 위한 PR인가요?
- [ ] 기능 추가 : 상품리스트페이지 배너 화살표 클릭시 상품 그리드 시작 위치로 스크롤
- [ ] 스타일 : 메인페이지 service, ai/tech, commerce 섹션의 텍스트 등장 순서를 이미지보다 앞으로 변경